### PR TITLE
Traverse the commit tree up to the root commit

### DIFF
--- a/bin/gitgraphia
+++ b/bin/gitgraphia
@@ -7,15 +7,15 @@ require 'gitgraphia'
 
 git_sha = 'HEAD'
 
-gitgraphia = Gitgraphia.new
+reader = Gitgraphia::Reader.new
 
-gitgraphia.parents_of(git_sha).each do |parent_sha|
+reader.parents_of(git_sha).each do |parent_sha|
   puts "commit #{git_sha} -[:has_parent]-> commit #{parent_sha}"
 end
 
-tree_sha = gitgraphia.tree_of(git_sha)
+tree_sha = reader.tree_of(git_sha)
 puts "commit #{git_sha} -[:represents]-> tree #{tree_sha}"
 
-gitgraphia.tree_to_files(tree_sha).each do |file|
+reader.tree_to_files(tree_sha).each do |file|
   puts "tree #{tree_sha} -[:contains]-> #{file}"
 end

--- a/bin/gitgraphia
+++ b/bin/gitgraphia
@@ -8,14 +8,19 @@ require 'gitgraphia'
 git_sha = 'HEAD'
 
 reader = Gitgraphia::Reader.new
+inspector = Gitgraphia::Inspector.new
 
-reader.parents_of(git_sha).each do |parent_sha|
-  puts "commit #{git_sha} -[:has_parent]-> commit #{parent_sha}"
-end
+inspector.find_branch_ancestry(git_sha).each do |commit_sha|
+  puts '----' * 30
 
-tree_sha = reader.tree_of(git_sha)
-puts "commit #{git_sha} -[:represents]-> tree #{tree_sha}"
+  reader.parents_of(commit_sha).each do |parent_sha|
+    puts "commit #{commit_sha} -[:has_parent]-> commit #{parent_sha}"
+  end
 
-reader.tree_to_files(tree_sha).each do |file|
-  puts "tree #{tree_sha} -[:contains]-> #{file}"
+  tree_sha = reader.tree_of(commit_sha)
+  puts "commit #{commit_sha} -[:represents]-> tree #{tree_sha}"
+
+  reader.tree_to_files(tree_sha).each do |file|
+    puts "tree #{tree_sha} -[:contains]-> #{file}"
+  end
 end

--- a/lib/gitgraphia.rb
+++ b/lib/gitgraphia.rb
@@ -4,3 +4,4 @@ module Gitgraphia
 end
 
 require_relative './gitgraphia/reader'
+require_relative './gitgraphia/inspector'

--- a/lib/gitgraphia.rb
+++ b/lib/gitgraphia.rb
@@ -1,26 +1,6 @@
 # frozen_string_literal: true
 
-class Gitgraphia
-  def object_of(git_sha)
-    `git cat-file -p #{git_sha}`.split("\n")
-  end
-
-  def tree_of(git_sha)
-    object_of(git_sha)
-      .select { |line| line =~ /^tree/ }
-      .map { |line| line.gsub(/^tree /, '') }
-      .first
-  end
-
-  def parents_of(git_sha)
-    object_of(git_sha)
-      .select { |line| line =~ /^parent/ }
-      .map { |line| line.gsub(/^parent /, '') }
-  end
-
-  def tree_to_files(tree_sha)
-    object_of(tree_sha)
-      .map { |line| line.split(nil, 4) }
-      .map { |line| { permissions: line[0], type: line[1], sha: line[2], name: line[3] } }
-  end
+module Gitgraphia
 end
+
+require_relative './gitgraphia/reader'

--- a/lib/gitgraphia/inspector.rb
+++ b/lib/gitgraphia/inspector.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Gitgraphia
+  class Inspector
+    def initialize
+      @reader = Gitgraphia::Reader.new
+    end
+
+    def find_branch_ancestry(start_commit_sha)
+      return [] unless start_commit_sha
+
+      branch_parent_sha = reader.parents_of(start_commit_sha).first
+      ancestry = find_branch_ancestry(branch_parent_sha)
+
+      [start_commit_sha].concat(ancestry)
+    end
+
+    private
+
+    attr_reader :reader
+  end
+end

--- a/lib/gitgraphia/reader.rb
+++ b/lib/gitgraphia/reader.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Gitgraphia
+  class Reader
+    def object_of(git_sha)
+      `git cat-file -p #{git_sha}`.split("\n")
+    end
+
+    def tree_of(git_sha)
+      object_of(git_sha)
+        .select { |line| line =~ /^tree/ }
+        .map { |line| line.gsub(/^tree /, '') }
+        .first
+    end
+
+    def parents_of(git_sha)
+      object_of(git_sha)
+        .select { |line| line =~ /^parent/ }
+        .map { |line| line.gsub(/^parent /, '') }
+    end
+
+    def tree_to_files(tree_sha)
+      object_of(tree_sha)
+        .map { |line| line.split(nil, 4) }
+        .map { |line| { permissions: line[0], type: line[1], sha: line[2], name: line[3] } }
+    end
+  end
+end

--- a/spec/gitgraphia/test_inspector.rb
+++ b/spec/gitgraphia/test_inspector.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'minitest/spec'
+require 'gitgraphia/inspector'
+
+describe Gitgraphia::Inspector do
+  # These are real commit SHAs on this repository from the `master` branch.
+  # Using real hashes is unconventional, but git is immutable and I don't have to mock `git cat-file` this way.
+  let(:root_commit_sha) { 'ab1527fbb47bbf110133a27f3a9043ba3a963062' }
+  let(:child_of_root_commit_sha) { 'd102418484007c2ca572860977a0ac3327a5d7c8' }
+  let(:merge_commit_sha) { '8dcc4e8f9da54ef5e8692642da2de15e5e78f233' }
+
+  let(:inspector) { Gitgraphia::Inspector.new }
+
+  describe '#find_branch_ancestry' do
+    it 'walks from the given commit SHA to the root commit keeping to the first parent' do
+      ancestry = inspector.find_branch_ancestry(merge_commit_sha)
+
+      #  *   8dcc4e8 Merge pull request #1 from sldblog/human-readable-concept -- merge_commit_sha
+      #  |\
+      #  | * 8895913 Add GitHub workflow to run tests
+      #  | * 883f2bb Add script describing the HEAD commit
+      #  |/
+      #  * d102418 Add the concept of the repository into the readme           -- child_of_root_commit_sha
+      #  * ab1527f Initial commit                                              -- root_commit_sha
+
+      _(ancestry).must_equal [
+        merge_commit_sha,
+        child_of_root_commit_sha,
+        root_commit_sha
+      ]
+    end
+  end
+end

--- a/spec/gitgraphia/test_reader.rb
+++ b/spec/gitgraphia/test_reader.rb
@@ -2,19 +2,19 @@
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'gitgraphia'
+require 'gitgraphia/reader'
 
-describe Gitgraphia do
+describe Gitgraphia::Reader do
   # These are real commit SHAs on this repository from the `master` branch.
   # Using real hashes is unconventional, but git is immutable and I don't have to mock `git cat-file` this way.
   let(:root_commit_sha) { 'ab1527fbb47bbf110133a27f3a9043ba3a963062' }
   let(:child_of_root_commit_sha) { 'd102418484007c2ca572860977a0ac3327a5d7c8' }
   let(:merge_commit_sha) { '8dcc4e8f9da54ef5e8692642da2de15e5e78f233' }
 
-  let(:gitgraphia) { Gitgraphia.new }
+  let(:reader) { Gitgraphia::Reader.new }
 
   describe '#parents_of' do
-    let(:parent_shas) { gitgraphia.parents_of(sha) }
+    let(:parent_shas) { reader.parents_of(sha) }
 
     describe 'the root commit' do
       let(:sha) { root_commit_sha }
@@ -42,7 +42,7 @@ describe Gitgraphia do
   end
 
   describe '#tree_of' do
-    let(:tree_sha) { gitgraphia.tree_of(sha) }
+    let(:tree_sha) { reader.tree_of(sha) }
 
     describe 'a commit' do
       let(:sha) { root_commit_sha }
@@ -55,7 +55,7 @@ describe Gitgraphia do
 
   describe '#tree_to_files' do
     let(:tree_sha) { "#{child_of_root_commit_sha}^{tree}" }
-    let(:files) { gitgraphia.tree_to_files(tree_sha) }
+    let(:files) { reader.tree_to_files(tree_sha) }
 
     describe 'a tree' do
       it 'always has a list of files' do
@@ -68,7 +68,7 @@ describe Gitgraphia do
   end
 
   describe 'object_of' do
-    let(:object_lines) { gitgraphia.object_of(sha) }
+    let(:object_lines) { reader.object_of(sha) }
 
     describe 'the root commit' do
       let(:sha) { root_commit_sha }


### PR DESCRIPTION
The initial version of the tool was inspecting only the `HEAD` commit.

With these changes, `bin/gitgraphia` will now walk backwards on the commit ancestry chain, keeping "left" to stay on the branch.

📝 **Caveat**: This logic relies on commits listing their "branch" parent as the first parent reference.